### PR TITLE
Update Dockerfile

### DIFF
--- a/my-terminus/Dockerfile
+++ b/my-terminus/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
-RUN for key in \
+RUN set -ex && for key in \
     4ED778F539E3634C779C87C6D7062848A1AB005C \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \


### PR DESCRIPTION
test with no `set` didn't progress us, so the `gpg --recv-keys` is definitely the failing part